### PR TITLE
add Kafka WebView by SourceLab.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,5 @@ Table of Contents
    * https://github.com/linkedin/Burrow
    * https://github.com/splee/burrower
    * https://github.com/yahoo/kafka-manager
+   * https://github.com/SourceLabOrg/kafka-webview
    * http://www.kafkatool.com/


### PR DESCRIPTION
Kafka WebView is a nice read-only alternative to Kafka Manager