### PR TITLE
Add Kafka Topology Builder (gitops for Kafka)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you're not inclined to make PRs, you can tweet me at `@infoslack`
 - https://github.com/tchiotludo/kafkahq
 - https://github.com/SourceLabOrg/kafka-webview
 - http://www.kafkatool.com/
+- https://github.com/kafka-ops/kafka-topology-builder Gitops and Automation for Apache Kafka
 - [Strimzi](https://github.com/strimzi/strimzi-kafka-operator) Operator for deploying and running Apache Kafka on Kubernetes and OpenShift
 - [kafkacat](https://github.com/edenhill/kafkacat) Generic CLI non-JVM Apache Kafka producer and consumer
 - [connectctl](https://github.com/90poe/connectctl) Manage kafka connect connectors easily


### PR DESCRIPTION
Adding the Kafka Topology Builder in the tools section to help with gitops automation in Kafka.