### PR TITLE
Add Kzmlabs StateFun Actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ If you're not inclined to make PRs, you can tweet me at `@infoslack`
 - [TypeStream](https://github.com/typestreamio/typestream) Open Source streaming platform. Write and run typed data pipelines with a minimal, familiar syntax. 
 - [Klag](https://github.com/themoah/klag) Fast and lightweight Kafka lag exporter, supports OTLP, Prometheus, Datadog and others.
 - [klag](https://github.com/closeup1202/klag) - CLI tool to diagnose why Kafka consumer lag is growing   
+- [Kzmlabs StateFun Actors](https://github.com/kzmlabs/flink-statefun) - Stateful actor framework on Apache Flink with first-class Kafka I/O — exactly-once delivery, durable per-key state, and a programming model where each Kafka key becomes an addressable function with its own persisted state.
 
 ## Docker Compose
 - [Kafka Cluster Kraft Mode - DockerCompose](https://github.com/minhhungit/kafka-kraft-cluster-docker-compose) - Workable kafka cluster with kraft mode using docker-compose


### PR DESCRIPTION
Adding Kzmlabs StateFun Actors under Tools. It's a stateful actor framework on Apache Flink with native Kafka ingress and egress.

Each Kafka key becomes an addressable function with its own persisted state, and the runtime gives you exactly-once delivery + per-key durable state without writing a Flink job by hand. It's a continuation of Apache Stateful Functions on Flink 2.2 + Java 21 (upstream stopped releasing in October 2024). Useful for fraud detection, real-time aggregation, and CDC consumers that need state larger than Kafka Streams' rocksdb store handles comfortably.

Apache 2.0, on Maven Central + GHCR. https://github.com/kzmlabs/flink-statefun